### PR TITLE
Add expiration of datapoints in checker

### DIFF
--- a/src/cmd/promremotebench/checker.go
+++ b/src/cmd/promremotebench/checker.go
@@ -61,13 +61,28 @@ type checker struct {
 
 	values  map[string]Datapoints
 	aggFunc aggFunc
+
+	expiredSeriesDuration time.Duration
+	targetLen             int
 }
 
-func newChecker(aggFunc aggFunc) Checker {
-	return &checker{
-		values:  make(map[string]Datapoints),
-		aggFunc: aggFunc,
+type checkerOptions struct {
+	aggFunc               aggFunc
+	cleanTickDuration     time.Duration
+	expiredSeriesDuration time.Duration
+	targetLen             int
+}
+
+func newChecker(opts checkerOptions) Checker {
+	c := &checker{
+		values:                make(map[string]Datapoints),
+		aggFunc:               opts.aggFunc,
+		expiredSeriesDuration: opts.expiredSeriesDuration,
+		targetLen:             opts.targetLen,
 	}
+
+	go c.cleanupLoop(opts.cleanTickDuration)
+	return c
 }
 
 func (c *checker) Store(hostSeries map[string][]prompb.TimeSeries) {
@@ -102,6 +117,44 @@ func (c *checker) GetHostNames() []string {
 	c.RUnlock()
 
 	return results
+}
+
+func (c *checker) cleanupLoop(loopDuration time.Duration) {
+	hostsToRemove := make([]string, 0, 4)
+	hostsToTrim := make([]string, 0, 20)
+
+	for {
+		time.Sleep(loopDuration)
+		now := time.Now()
+		c.RLock()
+		for host, values := range c.values {
+			if now.Sub(values[len(values)-1].Timestamp) > c.expiredSeriesDuration {
+				hostsToRemove = append(hostsToRemove, host)
+				continue
+			}
+
+			if len(values) > c.targetLen {
+				hostsToTrim = append(hostsToTrim, host)
+			}
+		}
+		c.RUnlock()
+
+		if len(hostsToRemove) > 0 || len(hostsToTrim) > 0 {
+			c.Lock()
+			for _, host := range hostsToRemove {
+				delete(c.values, host)
+			}
+
+			for _, host := range hostsToTrim {
+				copy(c.values[host][:], c.values[host][len(c.values[host])-c.targetLen:])
+				c.values[host] = c.values[host][:c.targetLen]
+			}
+			c.Unlock()
+		}
+
+		hostsToRemove = hostsToRemove[:0]
+		hostsToTrim = hostsToTrim[:0]
+	}
 }
 
 // promSeriesToM3Datapoint collapses Prometheus TimeSeries values to a single M3 datapoint

--- a/src/cmd/promremotebench/checker.go
+++ b/src/cmd/promremotebench/checker.go
@@ -128,13 +128,13 @@ func (c *checker) cleanupLoop(loopDuration time.Duration, numHosts int) {
 		now := time.Now()
 		c.RLock()
 		for host, values := range c.values {
-			// checking for hosts with no recent values (expired from generator)
+			// checking for hosts with no recent values (expired from generator).
 			if now.Sub(values[len(values)-1].Timestamp) > c.expiredSeriesDuration {
 				hostsToRemove = append(hostsToRemove, host)
 				continue
 			}
 
-			// checking to trim values once there are too many
+			// checking to trim values once there are too many.
 			if len(values) > c.targetLen {
 				hostsToTrim = append(hostsToTrim, host)
 			}
@@ -148,7 +148,7 @@ func (c *checker) cleanupLoop(loopDuration time.Duration, numHosts int) {
 			}
 
 			// trimming values by copying the most recent dps to the front and then truncating
-			// the slice
+			// the slice.
 			for _, host := range hostsToTrim {
 				copy(c.values[host][:], c.values[host][len(c.values[host])-c.targetLen:])
 				c.values[host] = c.values[host][:c.targetLen]

--- a/src/cmd/promremotebench/checker_test.go
+++ b/src/cmd/promremotebench/checker_test.go
@@ -36,7 +36,7 @@ func TestChecker(t *testing.T) {
 		cleanTickDuration:     time.Minute,
 		expiredSeriesDuration: time.Minute,
 		targetLen:             10,
-	})
+	}, 10)
 	hostGen := generators.NewHostsSimulator(10, time.Now(),
 		generators.HostsSimulatorOptions{})
 	series, err := hostGen.Generate(time.Second, time.Second, 0)
@@ -58,7 +58,7 @@ func TestCheckerCleanup(t *testing.T) {
 		cleanTickDuration:     15 * time.Millisecond,
 		expiredSeriesDuration: 20 * time.Millisecond,
 		targetLen:             2,
-	})
+	}, 2)
 
 	firstUnixMilliseconds := time.Now().Add(-30*time.Millisecond).UnixNano() / int64(time.Millisecond)
 

--- a/src/cmd/promremotebench/main.go
+++ b/src/cmd/promremotebench/main.go
@@ -315,7 +315,7 @@ func main() {
 		cleanTickDuration:     *checkerTick,
 		expiredSeriesDuration: *checkerExpiration,
 		targetLen:             *checkerTargetLen,
-	})
+	}, *numHosts)
 
 	// Start workloads.
 	if *write {


### PR DESCRIPTION
Datapoints currently accumulate in the checker leading to more memory usage over time. This change both trims the number of datapoints kept per host to a set threshold as well as removing old series that have expired due to new time series being introduced.