### PR TITLE
per code PROMREMOTEBENCH_INTERVAL is not relevant for scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ spec:
           value: "0.0.0.0:4242"
         - name: PROMREMOTEBENCH_NUM_HOSTS
           value: "1000"
-        - name: PROMREMOTEBENCH_INTERVAL
-          value: "10"
         - name: PROMREMOTEBENCH_NEW_SERIES_PERCENTAGE
           value: "0.01"
         ports:


### PR DESCRIPTION
Its confusing for users to wonder about how PROMREMOTEBENCH_INTERVAL might interact with the scraper's own interval.  Its actually not used when running in the scrape-target mode. Its best to get this line out of the README. 