### PR TITLE
Change format of step argument to float

### DIFF
--- a/src/cmd/promremotebench/query.go
+++ b/src/cmd/promremotebench/query.go
@@ -301,7 +301,7 @@ func (q *queryExecutor) fanoutQuery(
 	values.Set("query", query.String())
 	values.Set("start", strconv.Itoa(int(now.Add(-1*queryRange).Unix())))
 	values.Set("end", strconv.Itoa(int(now.Unix())))
-	values.Set("step", queryStep.String())
+	values.Set("step", strconv.FormatFloat(queryStep.Seconds(), 'f', -1, 64))
 
 	var (
 		wg       sync.WaitGroup


### PR DESCRIPTION
One minute value (which is the default) for `step` was failing with "invalid parameter 'step': cannot parse \"**1m0s**\" to a valid duration".
[Prometheus docs](https://prometheus.io/docs/prometheus/latest/querying/api/#format-overview) specify `duration` format as `[0-9]+[smhdwy]`. The [alternative format](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) for `step` is a float number of seconds which I believe would fit nicely here.
