### PR TITLE
Option to skip query accuracy checks

### DIFF
--- a/src/cmd/promremotebench/query.go
+++ b/src/cmd/promremotebench/query.go
@@ -69,6 +69,7 @@ type queryExecutorOptions struct {
 	NumSeries     int
 	LoadStep      time.Duration
 	LoadRange     time.Duration
+	SkipAccuracy  bool
 	AccuracyStep  time.Duration
 	AccuracyRange time.Duration
 	Aggregation   string
@@ -115,7 +116,11 @@ func (q *queryExecutor) Run(checker Checker) {
 		go q.alertLoad(checker)
 	}
 
-	go q.accuracyCheck(checker)
+	if q.SkipAccuracy {
+		q.Logger.Info("skipping query accuracy checks")
+	} else {
+		go q.accuracyCheck(checker)
+	}
 }
 
 // accuracyCheck checks the accuracy of data for one
@@ -195,7 +200,7 @@ func (q *queryExecutor) accuracyCheck(checker Checker) {
 				q.fanoutFailedError.Inc(1)
 			} else {
 				for url, result := range res {
-					if isValid := q.validateQuery(dps, result, selectedHost); isValid {
+					if q.validateQuery(dps, result, selectedHost) {
 						q.metrics[url].success.Inc(1)
 					} else {
 						q.metrics[url].validationFailedError.Inc(1)

--- a/src/cmd/promremotebench/write.go
+++ b/src/cmd/promremotebench/write.go
@@ -139,7 +139,6 @@ var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 
 // Client allows reading and writing from/to a remote HTTP endpoint.
 type Client struct {
-	index   int // Used to differentiate clients in metrics.
 	urls    []string
 	client  *http.Client
 	timeout time.Duration
@@ -210,10 +209,8 @@ func (c *Client) Store(ctx context.Context, headers map[string]string, req []byt
 		httpReq.Header.Set("Content-Type", "application/x-protobuf")
 		httpReq.Header.Set("User-Agent", userAgent)
 		httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
-		if headers != nil {
-			for k, v := range headers {
-				httpReq.Header.Set(k, v)
-			}
+		for k, v := range headers {
+			httpReq.Header.Set(k, v)
 		}
 		httpReq = httpReq.WithContext(ctx)
 


### PR DESCRIPTION
Query accuracy checks are always failing in case of parallel scraping (because of out of sync data scraped).
This change gives an option (cmd line and env var) to disable those checks.
Also, disabling accuracy check queries makes the query load easier to control (with accuracy checks disabled, the load directly depends on `query-concurrency` and `query-sleep` only).