### PR TITLE
Fix metrics names

### DIFF
--- a/src/cmd/promremotebench/scrape.go
+++ b/src/cmd/promremotebench/scrape.go
@@ -79,16 +79,17 @@ func (g *gatherer) Gather() ([]*dto.MetricFamily, error) {
 			var family *dto.MetricFamily
 
 			for j := range series[i].Labels {
-				name := series[i].Labels[j].Name
-				if name == labels.MetricName {
+				labelName := series[i].Labels[j].Name
+				if labelName == labels.MetricName {
+					metricName := series[i].Labels[j].Value
 					var ok bool
-					family, ok = families[name]
+					family, ok = families[metricName]
 					if !ok {
 						family = &dto.MetricFamily{
-							Name: &name,
+							Name: &metricName,
 							Type: &gauge,
 						}
-						families[name] = family
+						families[metricName] = family
 					}
 					break
 				}


### PR DESCRIPTION
Currently it emits `__name__` as the name for all the metrics generated, eg.:
```
# TYPE __name__ gauge
__name__{__name__="cpu",measurement="usage_user",hostname="host_44",region="us-east-1",datacenter="us-east-1a",rack="61",os="Ubuntu16.04LTS",arch="x86",team="NYC",service="2",service_version="1",service_environment="staging",generator="promremotebench-0"} 12.734722599121952
__name__{__name__="cpu",measurement="usage_system",hostname="host_44",region="us-east-1",datacenter="us-east-1a",rack="61",os="Ubuntu16.04LTS",arch="x86",team="NYC",service="2",service_version="1",service_environment="staging",generator="promremotebench-0"} 8.846770769005497
__name__{__name__="cpu",measurement="usage_idle",hostname="host_44",region="us-east-1",datacenter="us-east-1a",rack="61",os="Ubuntu16.04LTS",arch="x86",team="NYC",service="2",service_version="1",service_environment="staging",generator="promremotebench-0"} 51.35952142553164
```

After this fix:
```
# TYPE cpu gauge
cpu{__name__="cpu",measurement="usage_user",hostname="host_37",region="us-west-1",datacenter="us-west-1a",rack="78",os="Ubuntu16.10",arch="x64",team="LON",service="10",service_version="0",service_environment="test"} 92.65983780208313
cpu{__name__="cpu",measurement="usage_system",hostname="host_37",region="us-west-1",datacenter="us-west-1a",rack="78",os="Ubuntu16.10",arch="x64",team="LON",service="10",service_version="0",service_environment="test"} 75.43157657132639
cpu{__name__="cpu",measurement="usage_idle",hostname="host_37",region="us-west-1",datacenter="us-west-1a",rack="78",os="Ubuntu16.10",arch="x64",team="LON",service="10",service_version="0",service_environment="test"} 63.30110074549071
```